### PR TITLE
Collapse duplicated applier and filter logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,22 @@ final class PublishedFilter implements Filter
 }
 ```
 
+`$value` is a string when the request held a single value and a list when it held several, so a filter decides for itself
+what several values mean. For `LIKE` filters, extend `LikeFilter` instead and only describe the pattern — combining
+several values with `OR` is already handled:
+
+```php
+use EnricoDeLazzari\QueryBuilder\Filters\LikeFilter;
+
+final class ContainsWordFilter extends LikeFilter
+{
+    protected function pattern(string $value): string
+    {
+        return "% {$value} %";
+    }
+}
+```
+
 ## Sorting
 
 `?sort=title` orders ascending, `?sort=-title` descending. Several sorts are applied in the order they were requested:

--- a/src/Appliers/Applier.php
+++ b/src/Appliers/Applier.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EnricoDeLazzari\QueryBuilder\Appliers;
 
+use EnricoDeLazzari\QueryBuilder\Attributes\Allowed;
+use EnricoDeLazzari\QueryBuilder\Exceptions\InvalidQuery;
 use EnricoDeLazzari\QueryBuilder\QueryBuilderConfig;
 use Tempest\Database\Builder\QueryBuilders\SelectQueryBuilder;
 use Tempest\Http\Request;
@@ -24,7 +26,54 @@ abstract class Applier
     abstract public function apply(SelectQueryBuilder $query): void;
 
     /**
-     * Reads a query parameter, unwrapping the immutable arrays Tempest returns
+     * Reads the attributes of the given type off the query builder.
+     *
+     * @template TAllowed of Allowed
+     *
+     * @param  class-string<TAllowed>  $attribute
+     * @return TAllowed[]
+     */
+    protected function allowed(string $attribute): array
+    {
+        return $this->reflector->getAttributes($attribute);
+    }
+
+    /**
+     * Finds the attribute exposed under the given name.
+     *
+     * @template TAllowed of Allowed
+     *
+     * @param  TAllowed[]  $allowed
+     * @return TAllowed|null
+     */
+    protected function find(array $allowed, string $name): ?Allowed
+    {
+        return array_find($allowed, static fn (Allowed $item): bool => $item->name === $name);
+    }
+
+    /**
+     * Rejects requested names that were not allowed, unless strict mode is off.
+     *
+     * @param  string[]  $requested
+     * @param  Allowed[]  $allowed
+     * @param  class-string<InvalidQuery>  $exception
+     */
+    protected function guard(array $requested, array $allowed, string $exception): void
+    {
+        if (! $this->config->strict) {
+            return;
+        }
+
+        $names = array_map(static fn (Allowed $item): string => $item->name, $allowed);
+        $unknown = array_diff($requested, $names);
+
+        if ($unknown !== []) {
+            throw $exception::forNames($unknown, $names);
+        }
+    }
+
+    /**
+     * Reads a query parameter, unwrapping the immutable array Tempest returns
      * for nested values.
      */
     protected function parameter(string $name): mixed
@@ -41,10 +90,6 @@ abstract class Applier
      */
     protected function split(mixed $value, ?string $delimiter = null): array
     {
-        if ($value instanceof ImmutableArray) {
-            $value = $value->toArray();
-        }
-
         $values = is_array($value)
             ? $value
             : explode($delimiter ?? $this->config->delimiter, (string) $value);

--- a/src/Appliers/FiltersApplier.php
+++ b/src/Appliers/FiltersApplier.php
@@ -12,21 +12,16 @@ final class FiltersApplier extends Applier
 {
     public function apply(SelectQueryBuilder $query): void
     {
-        /** @var AllowedFilter[] $allowed */
-        $allowed = $this->reflector->getAttributes(AllowedFilter::class);
-
+        $allowed = $this->allowed(AllowedFilter::class);
         $requested = $this->requested();
 
-        $this->guard($requested, $allowed);
+        $this->guard(array_keys($requested), $allowed, InvalidFilterQuery::class);
 
         foreach ($allowed as $filter) {
-            $value = $requested[$filter->name] ?? $filter->default;
-
-            if ($value === null) {
-                continue;
-            }
-
-            $values = $this->split($value, $filter->delimiter);
+            $values = $this->split(
+                $requested[$filter->name] ?? $filter->default ?? '',
+                $filter->delimiter,
+            );
 
             if ($values === []) {
                 continue;
@@ -48,23 +43,5 @@ final class FiltersApplier extends Applier
         $filters = $this->parameter($this->config->filterParameter);
 
         return is_array($filters) ? $filters : [];
-    }
-
-    /**
-     * @param  array<string, mixed>  $requested
-     * @param  AllowedFilter[]  $allowed
-     */
-    private function guard(array $requested, array $allowed): void
-    {
-        if (! $this->config->strict) {
-            return;
-        }
-
-        $names = array_map(static fn (AllowedFilter $filter): string => $filter->name, $allowed);
-        $unknown = array_diff(array_keys($requested), $names);
-
-        if ($unknown !== []) {
-            throw InvalidFilterQuery::forNames($unknown, $names);
-        }
     }
 }

--- a/src/Appliers/IncludesApplier.php
+++ b/src/Appliers/IncludesApplier.php
@@ -12,48 +12,20 @@ final class IncludesApplier extends Applier
 {
     public function apply(SelectQueryBuilder $query): void
     {
-        /** @var AllowedInclude[] $allowed */
-        $allowed = $this->reflector->getAttributes(AllowedInclude::class);
+        $allowed = $this->allowed(AllowedInclude::class);
+        $requested = $this->split($this->parameter($this->config->includeParameter) ?? '');
 
-        $requested = $this->split(
-            $this->parameter($this->config->includeParameter) ?? [],
-        );
-
-        if ($requested === []) {
-            return;
-        }
-
-        $this->guard($requested, $allowed);
+        $this->guard($requested, $allowed, InvalidIncludeQuery::class);
 
         foreach ($requested as $name) {
-            $include = array_find(
-                $allowed,
-                static fn (AllowedInclude $include): bool => $include->name === $name,
-            );
+            // Only null when strict mode is off, since `guard` threw otherwise.
+            $include = $this->find($allowed, $name);
 
             if ($include === null) {
                 continue;
             }
 
             $include->include->apply($query, $include->relation());
-        }
-    }
-
-    /**
-     * @param  string[]  $requested
-     * @param  AllowedInclude[]  $allowed
-     */
-    private function guard(array $requested, array $allowed): void
-    {
-        if (! $this->config->strict) {
-            return;
-        }
-
-        $names = array_map(static fn (AllowedInclude $include): string => $include->name, $allowed);
-        $unknown = array_diff($requested, $names);
-
-        if ($unknown !== []) {
-            throw InvalidIncludeQuery::forNames($unknown, $names);
         }
     }
 }

--- a/src/Appliers/SortsApplier.php
+++ b/src/Appliers/SortsApplier.php
@@ -14,47 +14,35 @@ final class SortsApplier extends Applier
 {
     public function apply(SelectQueryBuilder $query): void
     {
-        $requested = $this->split(
-            $this->parameter($this->config->sortParameter) ?? [],
+        $allowed = $this->allowed(AllowedSort::class);
+        $requested = $this->split($this->parameter($this->config->sortParameter) ?? '');
+
+        $this->guard(
+            array_map($this->name(...), $requested),
+            $allowed,
+            InvalidSortQuery::class,
         );
 
-        if ($requested === []) {
+        /** @var array<array{AllowedSort, Direction}> $sorts */
+        $sorts = [];
+
+        foreach ($requested as $item) {
+            // Only null when strict mode is off, since `guard` threw otherwise.
+            $sort = $this->find($allowed, $this->name($item));
+
+            if ($sort !== null) {
+                $sorts[] = [$sort, $this->direction($item)];
+            }
+        }
+
+        if ($sorts === []) {
             $this->applyDefaults($query);
 
             return;
         }
 
-        /** @var AllowedSort[] $allowed */
-        $allowed = $this->reflector->getAttributes(AllowedSort::class);
-
-        $this->guard($requested, $allowed);
-
-        $applied = 0;
-
-        foreach ($requested as $item) {
-            $descending = str_starts_with($item, '-');
-            $name = $descending ? substr($item, 1) : $item;
-
-            $sort = array_find(
-                $allowed,
-                static fn (AllowedSort $sort): bool => $sort->name === $name,
-            );
-
-            if ($sort === null) {
-                continue;
-            }
-
-            $sort->sort->apply(
-                $query,
-                $sort->column(),
-                $descending ? Direction::DESC : Direction::ASC,
-            );
-
-            $applied++;
-        }
-
-        if ($applied === 0) {
-            $this->applyDefaults($query);
+        foreach ($sorts as [$sort, $direction]) {
+            $sort->sort->apply($query, $sort->column(), $direction);
         }
     }
 
@@ -69,24 +57,20 @@ final class SortsApplier extends Applier
     }
 
     /**
-     * @param  string[]  $requested
-     * @param  AllowedSort[]  $allowed
+     * Strips the leading hyphen that marks a descending sort.
      */
-    private function guard(array $requested, array $allowed): void
+    private function name(string $sort): string
     {
-        if (! $this->config->strict) {
-            return;
-        }
+        return $this->isDescending($sort) ? substr($sort, 1) : $sort;
+    }
 
-        $names = array_map(static fn (AllowedSort $sort): string => $sort->name, $allowed);
+    private function direction(string $sort): Direction
+    {
+        return $this->isDescending($sort) ? Direction::DESC : Direction::ASC;
+    }
 
-        $unknown = array_diff(
-            array_map(static fn (string $item): string => ltrim($item, '-'), $requested),
-            $names,
-        );
-
-        if ($unknown !== []) {
-            throw InvalidSortQuery::forNames($unknown, $names);
-        }
+    private function isDescending(string $sort): bool
+    {
+        return str_starts_with($sort, '-');
     }
 }

--- a/src/Attributes/Allowed.php
+++ b/src/Attributes/Allowed.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EnricoDeLazzari\QueryBuilder\Attributes;
+
+/**
+ * Something the query builder lets the request ask for under a given name.
+ */
+interface Allowed
+{
+    /**
+     * Name exposed in the query string.
+     */
+    public string $name {
+        get;
+    }
+}

--- a/src/Attributes/AllowedFilter.php
+++ b/src/Attributes/AllowedFilter.php
@@ -12,7 +12,7 @@ use EnricoDeLazzari\QueryBuilder\Filters\Filter;
  * Allows `?filter[name]=…` to be applied to the query.
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final readonly class AllowedFilter
+final readonly class AllowedFilter implements Allowed
 {
     public function __construct(
         /**

--- a/src/Attributes/AllowedInclude.php
+++ b/src/Attributes/AllowedInclude.php
@@ -12,7 +12,7 @@ use EnricoDeLazzari\QueryBuilder\Includes\RelationshipInclude;
  * Allows `?include=name` to eager load a relation on the query.
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final readonly class AllowedInclude
+final readonly class AllowedInclude implements Allowed
 {
     public function __construct(
         /**

--- a/src/Attributes/AllowedSort.php
+++ b/src/Attributes/AllowedSort.php
@@ -13,7 +13,7 @@ use EnricoDeLazzari\QueryBuilder\Sorts\Sort;
  * to the query.
  */
 #[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
-final readonly class AllowedSort
+final readonly class AllowedSort implements Allowed
 {
     public function __construct(
         /**

--- a/src/Exceptions/InvalidFilterQuery.php
+++ b/src/Exceptions/InvalidFilterQuery.php
@@ -6,8 +6,5 @@ namespace EnricoDeLazzari\QueryBuilder\Exceptions;
 
 final class InvalidFilterQuery extends InvalidQuery
 {
-    protected static function subject(): string
-    {
-        return 'filters';
-    }
+    protected const string SUBJECT = 'filter';
 }

--- a/src/Exceptions/InvalidIncludeQuery.php
+++ b/src/Exceptions/InvalidIncludeQuery.php
@@ -6,8 +6,5 @@ namespace EnricoDeLazzari\QueryBuilder\Exceptions;
 
 final class InvalidIncludeQuery extends InvalidQuery
 {
-    protected static function subject(): string
-    {
-        return 'includes';
-    }
+    protected const string SUBJECT = 'include';
 }

--- a/src/Exceptions/InvalidQuery.php
+++ b/src/Exceptions/InvalidQuery.php
@@ -17,6 +17,11 @@ use Tempest\Router\Exceptions\ConvertsToResponse;
 abstract class InvalidQuery extends Exception implements ConvertsToResponse, QueryBuilderException
 {
     /**
+     * Singular name of what was rejected, e.g. `filter`.
+     */
+    protected const string SUBJECT = 'parameter';
+
+    /**
      * @param  string[]  $requested  names that were rejected
      * @param  string[]  $allowed  names that would have been accepted
      */
@@ -24,13 +29,15 @@ abstract class InvalidQuery extends Exception implements ConvertsToResponse, Que
         public readonly array $requested,
         public readonly array $allowed,
     ) {
+        $single = count($requested) === 1;
+
         parent::__construct(sprintf(
-            'Requested %s `%s` %s not allowed. Allowed %s: %s.',
-            static::subject(),
-            implode('`, `', $requested),
-            count($requested) === 1 ? 'is' : 'are',
-            static::subject(),
-            $allowed === [] ? 'none' : '`'.implode('`, `', $allowed).'`',
+            '%s %s %s not allowed. Allowed %ss: %s.',
+            ucfirst($single ? static::SUBJECT : static::SUBJECT.'s'),
+            self::quote($requested),
+            $single ? 'is' : 'are',
+            static::SUBJECT,
+            $allowed === [] ? 'none' : self::quote($allowed),
         ));
     }
 
@@ -56,7 +63,10 @@ abstract class InvalidQuery extends Exception implements ConvertsToResponse, Que
     }
 
     /**
-     * Human readable name of what was rejected, e.g. `filters`.
+     * @param  string[]  $names
      */
-    abstract protected static function subject(): string;
+    private static function quote(array $names): string
+    {
+        return '`'.implode('`, `', $names).'`';
+    }
 }

--- a/src/Exceptions/InvalidSortQuery.php
+++ b/src/Exceptions/InvalidSortQuery.php
@@ -6,8 +6,5 @@ namespace EnricoDeLazzari\QueryBuilder\Exceptions;
 
 final class InvalidSortQuery extends InvalidQuery
 {
-    protected static function subject(): string
-    {
-        return 'sorts';
-    }
+    protected const string SUBJECT = 'sort';
 }

--- a/src/Filters/BeginsWithFilter.php
+++ b/src/Filters/BeginsWithFilter.php
@@ -4,26 +4,13 @@ declare(strict_types=1);
 
 namespace EnricoDeLazzari\QueryBuilder\Filters;
 
-use Tempest\Database\Builder\QueryBuilders\SelectQueryBuilder;
-use Tempest\Database\Builder\QueryBuilders\WhereGroupBuilder;
-
 /**
  * Matches a column against a `LIKE value%` pattern.
  */
-final class BeginsWithFilter implements Filter
+final class BeginsWithFilter extends LikeFilter
 {
-    public function apply(SelectQueryBuilder $query, string $column, string|array $value): void
+    protected function pattern(string $value): string
     {
-        if (! is_array($value)) {
-            $query->whereLike($column, "{$value}%");
-
-            return;
-        }
-
-        $query->whereGroup(function (WhereGroupBuilder $group) use ($column, $value): void {
-            foreach ($value as $item) {
-                $group->orWhereLike($column, "{$item}%");
-            }
-        });
+        return "{$value}%";
     }
 }

--- a/src/Filters/EndsWithFilter.php
+++ b/src/Filters/EndsWithFilter.php
@@ -4,26 +4,13 @@ declare(strict_types=1);
 
 namespace EnricoDeLazzari\QueryBuilder\Filters;
 
-use Tempest\Database\Builder\QueryBuilders\SelectQueryBuilder;
-use Tempest\Database\Builder\QueryBuilders\WhereGroupBuilder;
-
 /**
  * Matches a column against a `LIKE %value` pattern.
  */
-final class EndsWithFilter implements Filter
+final class EndsWithFilter extends LikeFilter
 {
-    public function apply(SelectQueryBuilder $query, string $column, string|array $value): void
+    protected function pattern(string $value): string
     {
-        if (! is_array($value)) {
-            $query->whereLike($column, "%{$value}");
-
-            return;
-        }
-
-        $query->whereGroup(function (WhereGroupBuilder $group) use ($column, $value): void {
-            foreach ($value as $item) {
-                $group->orWhereLike($column, "%{$item}");
-            }
-        });
+        return "%{$value}";
     }
 }

--- a/src/Filters/LikeFilter.php
+++ b/src/Filters/LikeFilter.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EnricoDeLazzari\QueryBuilder\Filters;
+
+use Tempest\Database\Builder\QueryBuilders\SelectQueryBuilder;
+use Tempest\Database\Builder\QueryBuilders\WhereGroupBuilder;
+
+/**
+ * Base for filters matching a column with `LIKE`. Several values are combined
+ * with `OR` inside a group, so `?filter[title]=a,b` matches either of them.
+ */
+abstract class LikeFilter implements Filter
+{
+    public function apply(SelectQueryBuilder $query, string $column, string|array $value): void
+    {
+        if (! is_array($value)) {
+            $query->whereLike($column, $this->pattern($value));
+
+            return;
+        }
+
+        $query->whereGroup(function (WhereGroupBuilder $group) use ($column, $value): void {
+            foreach ($value as $item) {
+                $group->orWhereLike($column, $this->pattern($item));
+            }
+        });
+    }
+
+    /**
+     * Turns a request value into the `LIKE` pattern to match against.
+     */
+    abstract protected function pattern(string $value): string;
+}

--- a/src/Filters/OperatorFilter.php
+++ b/src/Filters/OperatorFilter.php
@@ -19,18 +19,12 @@ final class OperatorFilter implements Filter
 
     public function apply(SelectQueryBuilder $query, string $column, string|array $value): void
     {
-        if ($this->operator->supportsArray()) {
-            $query->whereField($column, (array) $value, $this->operator);
-
-            return;
-        }
-
-        if (! $this->operator->requiresValue()) {
-            $query->whereField($column, null, $this->operator);
-
-            return;
-        }
-
-        $query->whereField($column, is_array($value) ? reset($value) : $value, $this->operator);
+        $query->whereField($column, match (true) {
+            $this->operator->supportsArray() => (array) $value,
+            ! $this->operator->requiresValue() => null,
+            // Operators taking a single value ignore any extra ones.
+            is_array($value) => $value[0],
+            default => $value,
+        }, $this->operator);
     }
 }

--- a/src/Filters/PartialFilter.php
+++ b/src/Filters/PartialFilter.php
@@ -4,31 +4,12 @@ declare(strict_types=1);
 
 namespace EnricoDeLazzari\QueryBuilder\Filters;
 
-use Tempest\Database\Builder\QueryBuilders\SelectQueryBuilder;
-use Tempest\Database\Builder\QueryBuilders\WhereGroupBuilder;
-
 /**
- * Matches a column against a `LIKE %value%` pattern. Several values are combined
- * with `OR` inside a group, so `?filter[title]=a,b` matches either of them.
+ * Matches a column against a `LIKE %value%` pattern.
  */
-final class PartialFilter implements Filter
+final class PartialFilter extends LikeFilter
 {
-    public function apply(SelectQueryBuilder $query, string $column, string|array $value): void
-    {
-        if (! is_array($value)) {
-            $query->whereLike($column, $this->pattern($value));
-
-            return;
-        }
-
-        $query->whereGroup(function (WhereGroupBuilder $group) use ($column, $value): void {
-            foreach ($value as $item) {
-                $group->orWhereLike($column, $this->pattern($item));
-            }
-        });
-    }
-
-    private function pattern(string $value): string
+    protected function pattern(string $value): string
     {
         return "%{$value}%";
     }

--- a/tests/FiltersTest.php
+++ b/tests/FiltersTest.php
@@ -261,7 +261,7 @@ it('rejects a filter that was not allowed', function () {
         {
             use HasQueryBuilder;
         };
-})->throws(InvalidFilterQuery::class, 'Requested filters `secret` is not allowed. Allowed filters: `title`.');
+})->throws(InvalidFilterQuery::class, 'Filter `secret` is not allowed. Allowed filters: `title`.');
 
 it('ignores a filter that was not allowed when strict mode is off', function () {
     $request = RequestFactory::make(['filter' => ['secret' => '1', 'title' => 'tempest']]);
@@ -277,3 +277,27 @@ it('ignores a filter that was not allowed when strict mode is off', function () 
     expect(sql($query))->toBe('SELECT '.BOOK_FIELDS.' FROM `books` WHERE `books`.`title` = ?');
     expect($query->bindings)->toBe(['tempest']);
 });
+
+it('lists every rejected filter when several were not allowed', function () {
+    $request = RequestFactory::make(['filter' => ['secret' => '1', 'hidden' => '2']]);
+
+    new
+        #[Model(Book::class)]
+        #[AllowedFilter('title')]
+        #[AllowedFilter('id')]
+        class($request)
+        {
+            use HasQueryBuilder;
+        };
+})->throws(InvalidFilterQuery::class, 'Filters `secret`, `hidden` are not allowed. Allowed filters: `title`, `id`.');
+
+it('reports that nothing is allowed when the query builder allows no filters', function () {
+    $request = RequestFactory::make(['filter' => ['secret' => '1']]);
+
+    new
+        #[Model(Book::class)]
+        class($request)
+        {
+            use HasQueryBuilder;
+        };
+})->throws(InvalidFilterQuery::class, 'Filter `secret` is not allowed. Allowed filters: none.');

--- a/tests/IncludesTest.php
+++ b/tests/IncludesTest.php
@@ -88,7 +88,7 @@ it('rejects an include that was not allowed', function () {
         {
             use HasQueryBuilder;
         };
-})->throws(InvalidIncludeQuery::class, 'Requested includes `secret` is not allowed. Allowed includes: `author`.');
+})->throws(InvalidIncludeQuery::class, 'Include `secret` is not allowed. Allowed includes: `author`.');
 
 it('ignores an include that was not allowed when strict mode is off', function () {
     $request = RequestFactory::make(['include' => 'secret,author']);

--- a/tests/SortsTest.php
+++ b/tests/SortsTest.php
@@ -146,7 +146,7 @@ it('rejects a sort that was not allowed', function () {
         {
             use HasQueryBuilder;
         };
-})->throws(InvalidSortQuery::class, 'Requested sorts `secret` is not allowed. Allowed sorts: `title`.');
+})->throws(InvalidSortQuery::class, 'Sort `secret` is not allowed. Allowed sorts: `title`.');
 
 it('ignores a sort that was not allowed when strict mode is off', function () {
     $request = RequestFactory::make(['sort' => 'secret,title']);
@@ -161,3 +161,15 @@ it('ignores a sort that was not allowed when strict mode is off', function () {
 
     expect(sql($query))->toBe('SELECT '.BOOK_FIELDS.' FROM `books` ORDER BY `books`.`title` ASC');
 });
+
+it('rejects a sort whose direction prefix is malformed', function () {
+    $request = RequestFactory::make(['sort' => '--title']);
+
+    new
+        #[Model(Book::class)]
+        #[AllowedSort('title')]
+        class($request)
+        {
+            use HasQueryBuilder;
+        };
+})->throws(InvalidSortQuery::class, 'Sort `-title` is not allowed. Allowed sorts: `title`.');


### PR DESCRIPTION
Follow-up to #17, which is already merged. Pure refactor of what landed there: no change to the public attribute syntax or to the SQL produced, except where noted below.

## Duplication removed

Three patterns were repeated almost verbatim.

**The `LIKE` filters were the same file three times.** `PartialFilter`, `BeginsWithFilter` and `EndsWithFilter` each carried the same scalar/array branch and the same `whereGroup` fallback, differing only in the pattern. They now extend a `LikeFilter` base that asks for the pattern alone:

```php
final class PartialFilter extends LikeFilter
{
    protected function pattern(string $value): string
    {
        return "%{$value}%";
    }
}
```

A custom `LIKE` filter now reduces to that method too, instead of having to reimplement the `OR` grouping.

**Each applier had its own `guard()`** doing the same strict-mode check, name extraction and `array_diff`. `AllowedFilter`, `AllowedSort` and `AllowedInclude` now share an `Allowed` interface exposing `name`, so `Applier` can provide `guard()`, `find()` and `allowed()` once. `DefaultSort` deliberately stays out of the interface: it is never matched against the request, so the distinction lives in the type rather than in a convention.

**The exception subclasses implemented an abstract static method** to return their subject. That is now a typed class constant, leaving each subclass a single line.

## Bug found while unifying the sort parsing

`guard()` stripped a sort's direction prefix with `ltrim($sort, '-')` (removes every leading hyphen) while application used `substr($sort, 1)` (removes one). With `?sort=--title` the allow-list saw `title` and let it through, then the match found nothing and the query silently fell back to the default sort — wrong results, no error. Both paths go through one helper now and `--title` is rejected. Covered by a test.

## Other changes

- Exception messages agree with their own number: ``Filter `x` is not allowed`` / ``Filters `x`, `y` are not allowed``, instead of the previous always-plural ``Requested filters ... is not allowed``. The three message assertions were updated and cases for the plural form and for an empty allow-list were added.
- Dropped an unreachable `ImmutableArray` branch in `split()`: Tempest's `get_by_key` only wraps the top level of a query parameter, which `parameter()` already unwraps.
- `SortsApplier` no longer needs an `$applied` counter — resolution is separated from application, so the fallback to the default sort is a single condition.

## Testing

52 tests, 80 assertions, green on the full CI matrix (PHP 8.5, ubuntu + windows, prefer-lowest + prefer-stable). Pint clean.

Net is −19 lines, which understates it: roughly 70 duplicated lines removed against 50 of shared abstraction added. The point is that each rule now lives in one place.

## Left alone

`QueryApplier` is still a ~30-line class that loops over three appliers and could be inlined into the trait, but it is the one place documenting the pipeline order. Happy to remove it if you'd rather.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLchYBsVhjLYNwpHj88Cqr)_