### PR TITLE
Stop running the test matrix twice per commit

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,12 @@
 name: Tests
 
 on:
+  # Restricted to the default branch: a branch with an open pull request is
+  # already covered by the `pull_request` trigger, and leaving both unrestricted
+  # ran the whole matrix twice for every commit.
   push:
+    branches:
+      - main
     paths:
       - '**.php'
       - '.github/workflows/run-tests.yml'


### PR DESCRIPTION
CI change only — one file, no source or test changes.

## The problem

`push` and `pull_request` were both unrestricted in `run-tests.yml`, so every commit on a branch with an open pull request fired two identical workflow runs. It is visible on both #17 and #18, which each show the full matrix twice.

The `concurrency` block does not deduplicate them, because `github.ref` differs between the two events — `refs/heads/<branch>` for the push and `refs/pull/<n>/merge` for the pull request — so they land in separate concurrency groups and neither cancels the other.

## The fix

`push` is now limited to the default branch:

```yaml
push:
  branches:
    - main
  paths: ...
pull_request:
  paths: ...
```

A branch under review is covered once by `pull_request`, and `main` is still tested after a merge. That halves the jobs per commit, from 8 to 4.

## Trade-off

Pushing to a branch with no pull request open no longer runs the tests. The alternative — keeping `push` unrestricted and dropping `pull_request` — would leave pull requests from forks untested, which seemed worse.

## Scope

The other three workflows do not have this problem and were left alone: `fix-php-code-style-issues` is `push`-only, `dependabot-auto-merge` runs on `pull_request_target`, and `update-changelog` on `release`.

Verified that the workflow YAML still parses and that the resulting trigger configuration is the intended one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLchYBsVhjLYNwpHj88Cqr)_